### PR TITLE
gigamon smilint fixes

### DIFF
--- a/gigamon/GIGAMON-SNMP-MIB.mib
+++ b/gigamon/GIGAMON-SNMP-MIB.mib
@@ -21,7 +21,7 @@ gigamonSnmp MODULE-IDENTITY
 
        email:   support@gigamon.com"
     DESCRIPTION
-    "Added notification type: 
+    "Added notification type:
       - gigamonSnmpBpsFailoverNotification
      Added notification objects:
       - gigamonSnmpNotifBpsUnitName
@@ -31,8 +31,8 @@ gigamonSnmp MODULE-IDENTITY
     "Added powerSupply OID to gigamonSystem MIB group"
     REVISION     "201308090000Z"
     DESCRIPTION
-    "Top-level infrastructure of Gigamon's MIB objects for 
-     GigaVUE-212, GigaVUE-420, GigaVUE-2404, 
+    "Top-level infrastructure of Gigamon's MIB objects for
+     GigaVUE-212, GigaVUE-420, GigaVUE-2404,
      GigaVUE-HD and GigaVUE-TA1"
     REVISION     "201304150000Z"
     DESCRIPTION
@@ -48,7 +48,7 @@ gigamonSnmp MODULE-IDENTITY
     "1) Updated GigaVUE product line support:
          (a) Added GigaVUE-TA1
          (b) Removed G-TAP and GigaVUE-MP
-     2) Added speed40000 and speed100000 in gigamonSnmpPortLinkSpeed 
+     2) Added speed40000 and speed100000 in gigamonSnmpPortLinkSpeed
         for representing 40G and 100G port speed"
     REVISION     "201203270000Z"
     DESCRIPTION
@@ -56,7 +56,7 @@ gigamonSnmp MODULE-IDENTITY
     REVISION     "201103250000Z"
     DESCRIPTION
     "Added the following notifications:
-      - gigamonSnmpCpuUtilHighNotification 
+      - gigamonSnmpCpuUtilHighNotification
       - gigamonSnmpUnexpectedShutdownNotification
       - gigamonSnmpDiskSpaceLowNotification"
     REVISION     "201103240000Z"
@@ -78,7 +78,7 @@ gigamonSnmp MODULE-IDENTITY
 --
 --  top level structure
 --
---  GigaVUE product line - GigaVUE-212, GigaVUE-420, GigaVUE-2404, 
+--  GigaVUE product line - GigaVUE-212, GigaVUE-420, GigaVUE-2404,
 --                         GigaVUE-HD, GigaVUE-TA1
 gigamonSnmpNotifications OBJECT IDENTIFIER  ::= { gigamonSnmp 1 }
 gigamonGigaVUE OBJECT IDENTIFIER            ::= { gigamonSnmpNotifications 1 }
@@ -88,7 +88,7 @@ gigamonSnmpNotificationObjects OBJECT IDENTIFIER
 gigamonSystem OBJECT IDENTIFIER             ::= { gigamonSnmp 2 }
 
 ------------------------------------------
--- System Information 
+-- System Information
 ------------------------------------------
 manufacturer OBJECT-TYPE
     SYNTAX      OCTET STRING
@@ -496,13 +496,13 @@ gigamonSnmpBatteryLevel OBJECT-TYPE
              0 - battery charge complete
              1 - battery level has been down below 75%
              2 - battery level has been down below 50%
-             3 - battery level has been down below 25% 
+             3 - battery level has been down below 25%
              4 - battery level has down to 15% or below and shutting down the system "
     ::= { gigamonSnmpNotificationObjects 23 }
 
 gigamonSnmpPortLinkSpeed OBJECT-TYPE
-    SYNTAX      INTEGER { 
-                notApply(0), 
+    SYNTAX      INTEGER {
+                notApply(0),
                 speed10(1),
                 speed100(2),
                 speed1000(3),
@@ -521,11 +521,11 @@ gigamonSnmpPortLinkSpeed OBJECT-TYPE
              4 - 10000 Mbps
              5 - 40000 Mbps
              6 - 100000 Mbps "
-    ::= { gigamonSnmpNotificationObjects 24 } 
+    ::= { gigamonSnmpNotificationObjects 24 }
 
 gigamonSnmpPortLinkDuplex OBJECT-TYPE
-    SYNTAX      INTEGER { 
-                notApply(0), 
+    SYNTAX      INTEGER {
+                notApply(0),
                 full(1),
                 half(2)
     }
@@ -536,7 +536,7 @@ gigamonSnmpPortLinkDuplex OBJECT-TYPE
              0 - Not Apply if link is down
              1 - full duplex
              2 - half duplex "
-    ::= { gigamonSnmpNotificationObjects 25 } 
+    ::= { gigamonSnmpNotificationObjects 25 }
 
 gigamonSnmpNotifCpuIndex OBJECT-TYPE
     SYNTAX      Unsigned32
@@ -806,6 +806,6 @@ gigamonSnmpBpsFailoverNotification NOTIFICATION-TYPE
     DESCRIPTION
         "Inline-bypass active unit change notification is the Edge/Level Triggered Event."
     ::= { gigamonGigaVUE 20 }
-    
+
 END
 

--- a/gigamon/GIGAMON-SNMP-MIB.mib
+++ b/gigamon/GIGAMON-SNMP-MIB.mib
@@ -5,14 +5,14 @@ GIGAMON-SNMP-MIB DEFINITIONS ::= BEGIN
 --
 
 IMPORTS
-    MODULE-IDENTITY, OBJECT-TYPE, enterprises, Integer32,
+    MODULE-IDENTITY, OBJECT-TYPE, enterprises, Integer32, Unsigned32,
     NOTIFICATION-TYPE                       FROM SNMPv2-SMI
     sysLocation                             FROM RFC1213-MIB
     TEXTUAL-CONVENTION, DisplayString,
     PhysAddress, TimeStamp                  FROM SNMPv2-TC;
 
 gigamonSnmp MODULE-IDENTITY
-    LAST-UPDATED "201304150000Z"
+    LAST-UPDATED "201805150000Z"
     ORGANIZATION "www.gigamon.com"
     CONTACT-INFO
      "postal:   Gigamon LLC
@@ -21,56 +21,59 @@ gigamonSnmp MODULE-IDENTITY
 
        email:   support@gigamon.com"
     DESCRIPTION
-    "Added notification type:
-      - gigamonSnmpBpsFailoverNotification
-     Added notification objects:
-      - gigamonSnmpNotifBpsUnitName
-      - gigamonSnmpNotifBpsFailoverStatus"
-    REVISION     "201309250000Z"
-    DESCRIPTION
-    "Added powerSupply OID to gigamonSystem MIB group"
-    REVISION     "201308090000Z"
-    DESCRIPTION
     "Top-level infrastructure of Gigamon's MIB objects for
      GigaVUE-212, GigaVUE-420, GigaVUE-2404,
      GigaVUE-HD and GigaVUE-TA1"
+
+    -- HISTORY
+    REVISION     "201805150000Z"
+    DESCRIPTION
+    " Fixed smilint errors"
+
+    REVISION     "201309250000Z"
+    DESCRIPTION
+    "Added powerSupply OID to gigamonSystem MIB group"
+
     REVISION     "201304150000Z"
     DESCRIPTION
     "Added 'license-mismatch' to gigamonSnmpNotifModuleOperationType"
+
     REVISION     "201212040000Z"
     DESCRIPTION
     "Added 'up' to gigamonSnmpNotifModuleOperationType"
+
     REVISION     "201205090000Z"
     DESCRIPTION
-    "Added new information found under gigamonSystem MIB group"
-    REVISION     "201205090000Z"
-    DESCRIPTION
-    "1) Updated GigaVUE product line support:
+    "Added new information found under gigamonSystem MIB group
+     1) Updated GigaVUE product line support:
          (a) Added GigaVUE-TA1
          (b) Removed G-TAP and GigaVUE-MP
      2) Added speed40000 and speed100000 in gigamonSnmpPortLinkSpeed
         for representing 40G and 100G port speed"
+
     REVISION     "201203270000Z"
     DESCRIPTION
     "Added 'shutdown' to gigamonSnmpNotifModuleOperationType"
+
     REVISION     "201103250000Z"
     DESCRIPTION
     "Added the following notifications:
       - gigamonSnmpCpuUtilHighNotification
       - gigamonSnmpUnexpectedShutdownNotification
       - gigamonSnmpDiskSpaceLowNotification"
+
     REVISION     "201103240000Z"
     DESCRIPTION
     "Added G-TAP support"
+
     REVISION     "201103030000Z"
     DESCRIPTION
     "Added GigaVUE-HD support"
+
     REVISION     "201007101000Z"
     DESCRIPTION
-    "Created notification definitions"
-    REVISION     "201007101000Z"
-    DESCRIPTION
-    "First draft"
+    "Created notification definitions. First draft"
+
     ::= { enterprises 26866 }
 
 --
@@ -580,7 +583,7 @@ gigamonSnmpNotifBpsUnitName OBJECT-TYPE
 gigamonSnmpNotifBpsFailoverStatus OBJECT-TYPE
     SYNTAX      INTEGER {
                     primary(0),
-                    secondary(1),
+                    secondary(1)
                 }
     MAX-ACCESS  accessible-for-notify
     STATUS      current


### PR DESCRIPTION
`$ smilint GIGAMON-SNMP-MIB.mib
GIGAMON-SNMP-MIB.mib:29: revision date after last update
GIGAMON-SNMP-MIB.mib:32: revision date after last update
GIGAMON-SNMP-MIB.mib:46: revision not in reverse chronological order
GIGAMON-SNMP-MIB.mib:71: revision not in reverse chronological order
GIGAMON-SNMP-MIB.mib:74: revision for last update is missing
GIGAMON-SNMP-MIB.mib:543: SMIv2 base type `Unsigned32' must be imported from SNMPv2-SMI
GIGAMON-SNMP-MIB.mib:584: syntax error, unexpected '}', expecting LOWERCASE_IDENTIFIER
GIGAMON-SNMP-MIB.mib:585: syntax error, unexpected MAX_ACCESS
GIGAMON-SNMP-MIB.mib:804: unknown object identifier label `gigamonSnmpNotifBpsFailoverStatus'
GIGAMON-SNMP-MIB.mib:799: object `gigamonSnmpNotifBpsFailoverStatus' of notification `gigamonSnmpBpsFailoverNotification' must be a scalar or column`