### PR TITLE
load ip-mib first (before rfc1213-mib)

### DIFF
--- a/EXTRAS/contrib/snmp.conf
+++ b/EXTRAS/contrib/snmp.conf
@@ -1,5 +1,4 @@
 ###########################################################################
-#   $Id$
 #
 #  Sample snmp.conf for using netdisco-mibs
 #
@@ -130,4 +129,4 @@ mibdirs +/usr/local/netdisco/mibs/xirrus
 #persistentDir /usr/local/netdisco/mibs
 
 mibreplacewithlatest  yes
-mibs ALL
+mibs IP-MIB:ALL


### PR DESCRIPTION
see netdisco/snmp-info c73bc0ca2c43017382af3b14b0010f67f3fd8901

should not matter since this file is not used by snmp::info or netdisco directly