### PR TITLE
allow underscores in netdisco mibs?

### DIFF
--- a/EXTRAS/contrib/Makefile
+++ b/EXTRAS/contrib/Makefile
@@ -1,8 +1,6 @@
 #
 # Netdisco MIBs Makefile
 #
-# $Source$
-# $Id$
 #
 
 MIBS    = $(shell grep ^Version mibs/README | sed -n -e 's/^Version //;P')

--- a/EXTRAS/contrib/UPGRADE
+++ b/EXTRAS/contrib/UPGRADE
@@ -125,7 +125,7 @@ or exactly the same and should be removed.
 net-snmp:
 ---------------------------------------------------------------------------
     cp -f net-snmp*/mibs/*.txt net-snmp
-    ./mk_index
+    ./mkindex
     ./rm_cisco_dups mib_index.txt net-snmp
     ./chk_mibs net-snmp
 

--- a/EXTRAS/contrib/snmp.conf
+++ b/EXTRAS/contrib/snmp.conf
@@ -1,12 +1,11 @@
 ###########################################################################
-#   $Id$
 #
 #  Sample snmp.conf for using netdisco-mibs
 #
-#   Run the command 'snmpconf' for help generating a harder file
+#  Run the command 'snmpconf' for help generating a harder file
 #                or 'man snmp.conf'
 #
-#   Usually you move this file to /usr/local/share/snmp/snmp.conf
+#  Usually you move this file to /usr/local/share/snmp/snmp.conf
 #                              or ~/.snmp/snmp.conf
 #
 #  Netdisco users : You can get away without doing this step, this just
@@ -132,5 +131,6 @@ mibdirs +/usr/local/netdisco/mibs/xirrus
 # This should only be needed by package maintainers.
 #persistentDir /usr/local/netdisco/mibs
 
-mibreplacewithlatest  yes
+mibreplacewithlatest yes
+mibAllowUnderline yes
 mibs ALL

--- a/EXTRAS/contrib/snmp.conf
+++ b/EXTRAS/contrib/snmp.conf
@@ -124,8 +124,8 @@ mibdirs +/usr/local/netdisco/mibs/xirrus
 #       cd mibs
 #       ln -s /usr/local/netdisco/mibs/*/* .
 
-# Versions 5.5+ no longer generate .index files in the mib directory
-# instead it stores mib indexes in the /var/net-snmp/mib_indexes which
+# Versions 5.5+ no longer generates .index files in the mib directory
+# instead it stores mib indexes in /var/net-snmp/mib_indexes which
 # may not be writable by non-root users.  Uncomment persistentDir to
 # change the base where the mib_indexes directory will be created.
 # This should only be needed by package maintainers.

--- a/EXTRAS/scripts/genxlate
+++ b/EXTRAS/scripts/genxlate
@@ -44,7 +44,7 @@ foreach my $v (@vendors) {
 
   defined(my $pid = fork) or die "Couldn't fork: $!";
   if (!$pid) { # Child
-    exec(qq{snmptranslate -Tt -Le -m '$mibs' 2>'$err' | perl -p -e 's/ tc=[0-9]+//g; s/anonymous#[0-9]*/anonymous/' 1>'$out'})
+    exec(qq{snmptranslate -Pu -Tt -Le -m '$mibs' 2>'$err' | perl -p -e 's/ tc=[0-9]+//g; s/anonymous#[0-9]*/anonymous/' 1>'$out'})
       or die "Couldn't exec: $!";
   } else { # Parent
     my $slept = 0.5;

--- a/EXTRAS/scripts/lib/Helpers.pm
+++ b/EXTRAS/scripts/lib/Helpers.pm
@@ -59,10 +59,10 @@ sub build_index {
   # change net-snmp perisistent dir and establish index baseline
   my $tmpdir = File::Temp->newdir();
   $ENV{SNMP_PERSISTENT_DIR} = $tmpdir->dirname;
-  qx(snmptranslate -IR sysName 2>&1 >/dev/null);
+  qx(snmptranslate -Pu -IR sysName 2>&1 >/dev/null);
   # now run snmptranslate to get the new index file
   my $newmibdirs = $ENV{MIBDIRS} .":$bundle";
-  qx(snmptranslate -M'$newmibdirs' -IR sysName 2>\&1 >/dev/null);
+  qx(snmptranslate -Pu -M'$newmibdirs' -IR sysName 2>\&1 >/dev/null);
   # restore persistent dir
   $ENV{SNMP_PERSISTENT_DIR} = "$ENV{MIBHOME}/EXTRAS/indexes";
 

--- a/EXTRAS/scripts/mkindex
+++ b/EXTRAS/scripts/mkindex
@@ -29,7 +29,7 @@ find(sub{ -d or unlink or die $! },
 
 # bootstrap initial three indexes
 status('net-snmp:rfc');
-system(q(snmptranslate -IR sysName | egrep -v '^SNMPv2-MIB::sysName$'));
+system(q(snmptranslate -Pu -IR sysName | egrep -v '^SNMPv2-MIB::sysName$'));
 
 # now for all the other dirs
 my $next = 2;
@@ -41,8 +41,8 @@ foreach (sort map {(splitdir($_))[-1]} grep {-d} glob("$ENV{MIBHOME}/*")) {
   my $newmibdirs = $ENV{MIBDIRS} .":$ENV{MIBHOME}/$_";
 
   $ENV{SNMP_PERSISTENT_DIR} = $tmpdir->dirname;
-  qx(snmptranslate -IR sysName 2>&1 >/dev/null);
-  system(qq(snmptranslate -M'$newmibdirs' -IR sysName | egrep -v '^SNMPv2-MIB::sysName\$'));
+  qx(snmptranslate -Pu -IR sysName 2>&1 >/dev/null);
+  system(qq(snmptranslate -Pu -M'$newmibdirs' -IR sysName | egrep -v '^SNMPv2-MIB::sysName\$'));
   $ENV{SNMP_PERSISTENT_DIR} = "$ENV{MIBHOME}/EXTRAS/indexes";
 
   copy("$tmpdir/mib_indexes/2", "$ENV{SNMP_PERSISTENT_DIR}/mib_indexes/$next");

--- a/EXTRAS/scripts/oldstyle/chk_dups
+++ b/EXTRAS/scripts/oldstyle/chk_dups
@@ -1,5 +1,5 @@
 #!/usr/bin/perl -w
-# chkdups - look for duplicate mibs files.
+# chk_dups - look for duplicate mibs files.
 
 my $file = shift || 'mib_index.txt';
 $diff    = shift ||  0;

--- a/EXTRAS/scripts/oldstyle/chk_mibs
+++ b/EXTRAS/scripts/oldstyle/chk_mibs
@@ -1,6 +1,6 @@
 #!/usr/bin/perl
-# chk_mib - fire up every mib in a dir to get it to parse
-#           and check for errors.
+# chk_mibs - fire up every mib in a dir to get it to parse
+#            and check for errors.
 # Max Baker
 # $Id$
 
@@ -10,7 +10,7 @@ my $mibs = shift || 'rfc:cisco:extreme';
 
 die "$0 dir mib_dirs\n" unless -d $dir;
 
-open (INDEX, "< $dir/.index") or die "Can't open .index in $dir. run ./mkindex.\n";
+open (INDEX, "< $dir/.index") or die "Can't open .index in $dir. run mkindex.\n";
 while (<INDEX>){
     if ($_ =~ /^(.*)\s+(.*)$/){
         my $mib = $1; my $file = $2;
@@ -21,7 +21,7 @@ close (INDEX);
 
 foreach my $mib (keys %MIBS){
     # boot up snmptranslate to make it parse the mib.
-    my $cmd = "snmptranslate -L e -M $dir:$mibs -m $mib ";
+    my $cmd = "snmptranslate -Pu -Le -M $dir:$mibs -m $mib ";
     my $check = `$cmd bork 2>&1`;
     # kill last line (our bogus error)
     $check =~ s/^.*\Z//m;

--- a/EXTRAS/scripts/oldstyle/mkindex
+++ b/EXTRAS/scripts/oldstyle/mkindex
@@ -10,7 +10,7 @@ echo "MIB Index" > $FILE
 
 # refresh index files
 for d in `find -L . -mindepth 1 -type d -not -name CVS | grep -v .git | sort`; do
-    snmptranslate -M$d sysName > /dev/null 2>&1
+    snmptranslate -Pu -M$d sysName > /dev/null 2>&1
 done
 
 # sort contents of index files

--- a/EXTRAS/scripts/testload
+++ b/EXTRAS/scripts/testload
@@ -32,7 +32,7 @@ my @mibs = (defined $vendor) ? @{$mibs_for->{$vendor}} : @{$allmibs};
 
 foreach my $mib (sort @mibs) {
   status("Testing $mib");
-  my $check = qx(snmptranslate -Le -m '$mib' bork 2>&1);
+  my $check = qx(snmptranslate -Pu -Le -m '$mib' bork 2>&1);
   # kill last line (our bogus error)
   $check =~ s/^.*\Z//m;
   if ($check !~ /^\s*$/){

--- a/EXTRAS/scripts/translateleaf
+++ b/EXTRAS/scripts/translateleaf
@@ -41,7 +41,7 @@ print CYAN, "\N{ALMOST EQUAL TO} translating for '$vendor'", CLEAR "\n";
 
 defined(my $pid = fork) or die "Couldn't fork: $!";
 if (!$pid) { # Child
-  exec(qq{snmptranslate -IR -Le -m '$mibs' $oid})
+  exec(qq{snmptranslate -Pu -IR -Le -m '$mibs' $oid})
     or die "Couldn't exec: $!";
 } else { # Parent
   while (! waitpid($pid, WNOHANG)) {

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ Originally by Max Baker, 2004
     Version 4.018
 
     This is a workable set of SNMP MIBs to use with Netdisco 
-    and other network managment tools. All glitches have been
+    and other network management tools. All glitches have been
     painstakingly fixed up to parse correctly under the latest
     release of net-snmp.
 


### PR DESCRIPTION
while strictly not allowed in smi, some vendors (aerohive) use underscores in object defs. this allows the use of them in netdisco-mibs