### PR TITLE
new script for a unified perl module

### DIFF
--- a/EXTRAS/scripts/setmibdev
+++ b/EXTRAS/scripts/setmibdev
@@ -1,0 +1,103 @@
+#!/usr/bin/env perl
+# setmibdev - use a seperate snmp module that's just for
+# netdisco mib development
+
+use strict;
+use warnings;
+
+use charnames ':full';
+binmode STDOUT, ':utf8';
+$|++;
+
+use File::Temp;
+use File::Path ();
+use Time::HiRes 'sleep';
+use Term::ANSIColor qw(:constants);
+use File::Spec::Functions qw(splitdir catfile);
+use Text::ParseWords 'shellwords';
+use IPC::Open3 'open3';
+use POSIX qw(:sys_wait_h);
+
+use FindBin;
+use lib catfile($FindBin::Bin, 'lib');
+use Helpers;
+
+our $NOTAVERSION = '2.0';
+my $home = "$ENV{MIBHOME}/EXTRAS/net-snmp.local";
+my $localenv = "$home/bin/localenv";
+my $cpanm = 'cpanm --quiet --notest';
+my $success = "$home/.success_$NOTAVERSION";
+my %envbak = (); # backup %ENV
+
+if (not -e $success) {
+  File::Path::remove_tree($home);
+  mkdir $home;
+
+  bld(
+    qq{ curl -sL https://cpanmin.us/ | perl - --quiet --notest --local-lib '$home' }
+    .q{ App::cpanminus App::local::lib::helper PkgConfig Test::CChecker }
+    .q{ Alien::zlib::Static }, 'net-snmp dependencies(1)');
+
+  # back up and update environment
+  foreach my $key (shellwords(bld(qq{ '$localenv' zlib-env-perl KEYS },
+                                  'env(1a)'))) {
+    $envbak{$key} = $ENV{$key} if !exists $envbak{$key};
+    $ENV{$key} = bld(qq{ '$localenv' zlib-env-perl $key }, 'env(1b)');
+  }
+
+  bld(qq{ '$localenv' $cpanm Alien::OpenSSL::Static },
+    'net-snmp dependencies(2)');
+
+  # back up and update environment
+  foreach my $key (shellwords(bld(qq{ '$localenv' openssl-env-perl KEYS },
+                                  'env(2a)'))) {
+    $envbak{$key} = $ENV{$key} if !exists $envbak{$key};
+    $ENV{$key} = bld(qq{ '$localenv' openssl-env-perl $key }, 'env(2b)');
+  }
+
+  bld(qq{ '$localenv' $cpanm --installdeps Alien::SNMP::MIBDEV },
+    'net-snmp dependencies(3)');
+
+  # restore environment
+  foreach my $key (keys %envbak) {
+    delete $ENV{$key};
+    $ENV{$key} = $envbak{$key} if $envbak{$key};
+  }
+
+  bld(qq{ '$localenv' $cpanm Alien::SNMP::MIBDEV },
+    'net-snmp');
+
+  open(my $ok, '>', $success) or die $!;  close $ok;
+}
+
+print "\N{HEAVY CHECK MARK} Entering localenv...\n";
+my $bindir = qx('$localenv' perl -MAlien::SNMP::MIBDEV -e 'print Alien::SNMP::MIBDEV->bin_dir');
+exec(qq{'$localenv' $ENV{SHELL} -c 'export PATH="$bindir:\$PATH";\$SHELL'});
+
+sub bld {
+  my $target = shift || return;
+  my $alias  = shift || return;
+  my $out = File::Temp->new();
+  my $err = File::Temp->new();
+  my $in  = '';
+
+  my $pid = open3($in, $out, $err, $target);
+  while (! waitpid($pid, WNOHANG)) {
+    status("Building $alias...");
+    sleep 0.05;
+  }
+  my $child_exit_status = $? >> 8;
+  seek($_, 0, 0) for ($out, $err);
+  ($out, $err) = (<$out>, <$err>);
+
+  blank();
+  if ($child_exit_status) {
+    print RED, "\N{HEAVY BALLOT X} ", CYAN,
+      "Errors from $alias build:\n", RESET;
+    print $out, "\n---\n" if $out;
+    print $err, "\n---\n" if $err;
+    exit 1;
+  }
+
+  return $out;
+}

--- a/EXTRAS/scripts/setmibdev
+++ b/EXTRAS/scripts/setmibdev
@@ -22,11 +22,15 @@ use FindBin;
 use lib catfile($FindBin::Bin, 'lib');
 use Helpers;
 
-our $NOTAVERSION = '2.0';
+unless (defined $ENV{'MIBHOME'}) {
+  die "error: MIBHOME not set\n";
+}
+
+our $MIBDEVVERSION = '2.020000';
 my $home = "$ENV{MIBHOME}/EXTRAS/net-snmp.local";
 my $localenv = "$home/bin/localenv";
 my $cpanm = 'cpanm --quiet --notest';
-my $success = "$home/.success_$NOTAVERSION";
+my $success = "$home/.success_mibdev_$MIBDEVVERSION";
 my %envbak = (); # backup %ENV
 
 if (not -e $success) {
@@ -55,7 +59,7 @@ if (not -e $success) {
     $ENV{$key} = bld(qq{ '$localenv' openssl-env-perl $key }, 'env(2b)');
   }
 
-  bld(qq{ '$localenv' $cpanm --installdeps Alien::SNMP::MIBDEV },
+  bld(qq{ '$localenv' $cpanm --installdeps Alien::SNMP::MIBDEV@$MIBDEVVERSION },
     'net-snmp dependencies(3)');
 
   # restore environment
@@ -64,7 +68,7 @@ if (not -e $success) {
     $ENV{$key} = $envbak{$key} if $envbak{$key};
   }
 
-  bld(qq{ '$localenv' $cpanm Alien::SNMP::MIBDEV },
+  bld(qq{ '$localenv' $cpanm Alien::SNMP::MIBDEV@$MIBDEVVERSION },
     'net-snmp');
 
   open(my $ok, '>', $success) or die $!;  close $ok;

--- a/EXTRAS/scripts/setmibdev
+++ b/EXTRAS/scripts/setmibdev
@@ -55,7 +55,7 @@ if (not -e $success) {
     $ENV{$key} = bld(qq{ '$localenv' openssl-env-perl $key }, 'env(2b)');
   }
 
-  bld(qq{ '$localenv' $cpanm --installdeps Alien::SNMP::MIBDEV@$MIBDEVVERSION },
+  bld(qq{ '$localenv' $cpanm --installdeps Alien::SNMP::MIBDEV\@$MIBDEVVERSION },
     'net-snmp dependencies(3)');
 
   # restore environment
@@ -64,7 +64,7 @@ if (not -e $success) {
     $ENV{$key} = $envbak{$key} if $envbak{$key};
   }
 
-  bld(qq{ '$localenv' $cpanm Alien::SNMP::MIBDEV@$MIBDEVVERSION },
+  bld(qq{ '$localenv' $cpanm Alien::SNMP::MIBDEV\@$MIBDEVVERSION },
     'net-snmp');
 
   open(my $ok, '>', $success) or die $!;  close $ok;

--- a/EXTRAS/scripts/setmibdev
+++ b/EXTRAS/scripts/setmibdev
@@ -22,10 +22,6 @@ use FindBin;
 use lib catfile($FindBin::Bin, 'lib');
 use Helpers;
 
-unless (defined $ENV{'MIBHOME'}) {
-  die "error: MIBHOME not set\n";
-}
-
 our $MIBDEVVERSION = '2.020000';
 my $home = "$ENV{MIBHOME}/EXTRAS/net-snmp.local";
 my $localenv = "$home/bin/localenv";


### PR DESCRIPTION
get rid of trying to figure out which alien::snmp to use & just always go for Alien::SNMP::MIBDEV , an alien module made just netdisco-mibs development. it has been published to cpan alrdy.

is there any reason setmaxtc tries so hard to find out the net-snmp version? in my experience it always ends up building anyway. (tested on systems with 5.7.3, 5.8 & 5.9)

based on alien::snmp::maxtc but raises max_imports instead which fixes this problem:

```
testdisc@linux002:~/src/netdisco-mibs> EXTRAS/scripts/testload ciscoucs
✘ Errors from CISCO-UNIFIED-COMPUTING-FABRIC-MIB in ciscoucs/CISCO-UNIFIED-COMPUTING-FABRIC-MIB.my
Too many imported symbols (CucsFabricSanCloudFsmTaskItem): At line 287 in /home/testdisc/src/netdisco-mibs/ciscoucs/CISCO-UNIFIED-COMPUTING-FABRIC-MIB.my
Unlinked OID in CISCO-UNIFIED-COMPUTING-FABRIC-MIB: cucsFabricObjects ::= { ciscoUnifiedComputingMIBObjects 19 }
Undefined identifier: ciscoUnifiedComputingMIBObjects near line 360 of /home/testdisc/src/netdisco-mibs/ciscoucs/CISCO-UNIFIED-COMPUTING-FABRIC-MIB.my
```

still a draft since i would like to move to net-snmp 5.9 to fix https://github.com/netdisco/netdisco-mibs/issues/104 (5.9 does ordering of mibs, so we are no longer dependant of the order the filesystem returns them in).
5.9 also completely rips out the file caching which makes it useless for us, unless we rewrite our scripts.

the caching code however might be that hard to backport into this alien module:
https://github.com/net-snmp/net-snmp/commit/4fd9a450444a434a993bc72f7c3486ccce41f602


thoughts / comments? either here on on irc.
